### PR TITLE
Fix Issues 2 and 3

### DIFF
--- a/nameCollector.cpp
+++ b/nameCollector.cpp
@@ -39,7 +39,7 @@ bool           DEBUG = false;                     // Debug flag from CLI option
 // identifier, type, filename, position
 void printCSV(std::ostream& out, const std::vector<identifier>& identifiers) {
     //out << "IDENTIFIER" << ", TYPE" << ", FILENAME" << ", POSITION" << std::endl;
-    for (unsigned int i = 0; i<identifiers.size(); ++i)
+    for (unsigned int i = 0; i < identifiers.size(); ++i)
         out << identifiers[i] << std::endl;
 }
 
@@ -48,9 +48,10 @@ void printReport(std::ostream& out, const std::vector<identifier>& identifiers) 
     out << "The following " << identifiers.size() << " user defined identifiers occur: " << std::endl;
     for (unsigned int i = 0; i<identifiers.size(); ++i) {
         out << identifiers[i].getName()
-            << " is a "     << identifiers[i].getCategory()
+            << " is a " << identifiers[i].getType()
+            << (identifiers[i].getType() != "" ? " " : "") << identifiers[i].getCategory()
             << " in file: " << identifiers[i].getFilename()
-            << " at "       << identifiers[i].getPosition()
+            << (identifiers[i].getPosition() != "" ? " at " : "") <<  identifiers[i].getPosition()
             << std::endl;
     }
 }

--- a/nameCollectorHandler.hpp
+++ b/nameCollectorHandler.hpp
@@ -156,9 +156,8 @@ public:
 
         if (std::string(localname) == "name") {
             collectContent = true;
-            if (numAttributes >= 1) {
+            if (numAttributes >= 1)
                 position = attributes[0].value;
-            }
         }
         else if (std::string(localname) == "type") {
             // Check if this is a type ref=prev
@@ -276,6 +275,12 @@ public:
 
         else if (std::string(localname) == "type") {
             typeStack[typeStack.size()-1].gatherContent = false;
+        }
+
+        else if (std::string(localname) == "operator") {
+            if (elementStack.back() == "name2") {
+                identifiers.erase(identifiers.end() - 1);
+            }
         }
 
         else if (typeStack.size() != 0)


### PR DESCRIPTION
Addresses Issues 2 and 3.

Issue 2:
- If a type is present, prints it before the category - i.e., `x is a int local`, `substr is a String function`. This ignores things which don't have types.
- Additionally, if the input srcML was not run with the `--position` flag, `at` will no longer print.

Issue 3:
- Declarations with namespace scopes in their name will no longer have duplicate entries for the namespace itself.
- This is accomplished by checking for an operator inside the name, and removing the previous erroneously added entry.