### PR TITLE
Issue 5

### DIFF
--- a/nameCollectorHandler.hpp
+++ b/nameCollectorHandler.hpp
@@ -289,15 +289,6 @@ public:
                     std::cout <<  "------------------------" << std::endl;
                 }
             }
-            else {
-                std::cout << "SPECIAL NAME " << category << "|" << content << std::endl;
-                std::cout << "Stack: " ;
-                for (int i=elementStack.size()-1; i>=0; --i) {
-                    std::cout << elementStack[i] << " | ";
-                }
-                std::cout << std::endl;
-                std::cout <<  "------------------------" << std::endl;
-            }
 
             content = "";
             position = "";
@@ -309,25 +300,20 @@ public:
             typeStack[typeStack.size()-1].gatherContent = false;
         }
 
+        // If an operator (::) is found in a signifigant name, delete previous name
         else if (std::string(localname) == "operator") {
             if (elementStack.back().find("operator_name_") == 0) {
                 int depth = std::stoi(elementStack.back().substr(14));
                 if(isUserDefinedIdentifier(elementStack[elementStack.size()-(depth+1)])) {
+
                     if(DEBUG) {
-                        std::cout << "DELETEING" << std::endl;
-                        std::cout << "Stack Before: " << std::endl;
-                        for(int i = 0; i < identifiers.size(); ++i) {
-                            std::cout << i << ": " << identifiers[i] << std::endl;
-                        }
-                    }
-                    identifiers.erase(identifiers.end() - 1);
-                    if(DEBUG) {
-                        std::cout << "Stack After: " << std::endl;
-                        for(int i = 0; i < identifiers.size(); ++i) {
-                            std::cout << i << ": " << identifiers[i] << std::endl;
-                        }
+                        std::cout << "Removing " << identifiers[identifiers.size() - 1] << " from stack" << std::endl;
                         std::cout <<  "------------------------" << std::endl;
                     }
+
+                    identifiers.erase(identifiers.end() - 1);
+
+                    
                 }
             }
         }


### PR DESCRIPTION
There were 2 main cases that the previous fix broke

1) When a complex name goes three layers deep, nameCollector would error and cause the element stack to be [name, name2, name, ...]. This meant that these names would be skipped entirely. When the function looked like this: stack<T>::pop(), the <T> was 3 layers deep, which caused the entire left side to be skipped. Then, when the :: was encountered, my previous fix triggered, deleting whatever was last added. I have fixed this by making nameCollector count the depth of names, so the name stack will instead look like [name_3, name_2, name, ...]. 

2) The other case was because my previous fix wasn't selective enough about what operators in names should trigger a delete. At any time, if there was an expression of something like this ptr->next, because -> is an operator within a name, the check would run and delete the previously gathered name. I fixed this by also adding a check for the situation of the operator, so it will only fire if we are inside a name category that is significant to us.