### PR TITLE
Add support for optional stereotyping information

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ Works for C, C++, C#, and Java
 
 Input: A srcML file of source code with --position option.  srcML file can be a single unit (one source code file) or an archive (multiple source code files).
 
-Output: A list of identifier names,  their type (for declartions and functions), their syntactic category, the file name, and position (line:column) the identifier occurs (declared), and the programming langauge.  Output is plain text (default) or csv (with no header).
+Output: A list of identifier names,  their type (for declartions and functions), their stereotype (from [stereocode](https://github.com/srcML/stereocode) - optional), their syntactic category, the file name, and position (line:column) the identifier occurs (declared), and the programming langauge.  Output is plain text (default) or csv (with no header).
 
 Example:
 
-| Name            | Type     | Category   | File   | Position | Language |
-| --------------- | -------------- |---|---|---|---|
-|foo| char |function| foo.cpp | 10:5 | C++ |
-|x| double | parameter| foo.cpp | 10:15| C++ |
-|i| int | local| foo.cpp | 12:10| C++ |
-|stack|   | class | foo.cpp | 15:7| C++ |
+| Name            | Type     | Stereotype    | Category   | File   | Position | Language |
+| --------------- | -------------- | -------- |---|---|---|---|
+|foo| char |function| get | foo.cpp | 10:5 | C++ |
+|x| double | parameter| | foo.cpp | 10:15| C++ |
+|i| int | local| | foo.cpp | 12:10| C++ |
+|stack|   | class | small-class | foo.cpp | 15:7| C++ |
 
 ## Identifier Syntactic Categories Supported C, C++, C#, Java:
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Example:
 
 | Name            | Type     | Category   | File   | Position | Language | Stereotype    |
 | --------------- | -------------- | -------- |---|---|---|---|
-|foo| char | function | get | foo.cpp | 10:5 | C++ | get |
-|x| double | parameter | foo.cpp | 10:15| C++ | | 
+|foo| char | function | foo.cpp | 10:5 | C++ | get |
+|x| double | parameter | foo.cpp | 10:15| C++ |  | 
 |i| int | local | foo.cpp | 12:10 | C++ | | 
-|stack|   | class | small-class | foo.cpp | 15:7| C++ | small-class |
+|stack|   | class | foo.cpp | 15:7| C++ | small-class |
 
 ## Identifier Syntactic Categories Supported C, C++, C#, Java:
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ Works for C, C++, C#, and Java
 
 Input: A srcML file of source code with --position option.  srcML file can be a single unit (one source code file) or an archive (multiple source code files).
 
-Output: A list of identifier names,  their type (for declartions and functions), their stereotype (from [stereocode](https://github.com/srcML/stereocode) - optional), their syntactic category, the file name, and position (line:column) the identifier occurs (declared), and the programming langauge.  Output is plain text (default) or csv (with no header).
+Output: A list of identifier names,  their type (for declartions and functions), their syntactic category, the file name, and position (line:column) the identifier occurs (declared), the programming langauge, and for methods and classes their stereotype (from [stereocode](https://github.com/srcML/stereocode) l) if it is in the srcML.  Output is plain text (default) or csv (with no header).
 
 Example:
 
-| Name            | Type     | Stereotype    | Category   | File   | Position | Language |
+| Name            | Type     | Category   | File   | Position | Language | Stereotype    |
 | --------------- | -------------- | -------- |---|---|---|---|
-|foo| char |function| get | foo.cpp | 10:5 | C++ |
-|x| double | parameter| | foo.cpp | 10:15| C++ |
-|i| int | local| | foo.cpp | 12:10| C++ |
-|stack|   | class | small-class | foo.cpp | 15:7| C++ |
+|foo| char | function | get | foo.cpp | 10:5 | C++ | get |
+|x| double | parameter | foo.cpp | 10:15| C++ | | 
+|i| int | local | foo.cpp | 12:10 | C++ | | 
+|stack|   | class | small-class | foo.cpp | 15:7| C++ | small-class |
 
 ## Identifier Syntactic Categories Supported C, C++, C#, Java:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Works for C, C++, C#, and Java
 
 Input: A srcML file of source code with --position option.  srcML file can be a single unit (one source code file) or an archive (multiple source code files).
 
-Output: A list of identifier names,  their type (for declartions and functions), their syntactic category, the file name, and position (line:column) the identifier occurs (declared), the programming langauge, and for methods and classes their stereotype (from [stereocode](https://github.com/srcML/stereocode) l) if it is in the srcML.  Output is plain text (default) or csv (with no header).
+Output: A list of identifier names,  their type (for declartions and functions), their syntactic category, the file name, and position (line:column) the identifier occurs (declared), the programming langauge, and for methods and classes their stereotype, from [stereocode](https://github.com/srcML/stereocode), if it is in the srcML.  Output is plain text (default) or csv (with no header).
 
 Example:
 

--- a/identifierName.hpp
+++ b/identifierName.hpp
@@ -101,6 +101,16 @@ const std::unordered_set<std::string> TYPED_CATEGORIES = {
     "property" //C# only
 };
 
+const std::unordered_set<std::string> STEREOTYPED_CATEGORIES = {
+    "function",
+    "class",
+    "struct",
+    "constructor",
+    "destructor",
+    "interface", // Java only
+    "union"
+};
+
 
 //Does this tag contain a user defined name?
 //
@@ -111,6 +121,11 @@ bool isUserDefinedIdentifier(const std::string& category) {
 // Does this tag contain a type?
 bool isTypedCategory(const std::string& category) {
     return TYPED_CATEGORIES.find(category) != TYPED_CATEGORIES.end();
+}
+
+// Is this tag stereotypable?
+bool isStereotypableCategory(const std::string& category) {
+    return STEREOTYPED_CATEGORIES.find(category) != STEREOTYPED_CATEGORIES.end();
 }
 
 struct typeInfo {
@@ -168,10 +183,10 @@ protected:
 
 //CSV output name, category, filename, position
 std::ostream& operator<<(std::ostream& out, const identifier& id) {
-    out << id.getName()       << ", " << id.getType()     << ", "
-        << id.getStereotype() << ", " << id.getCategory() << ", "
-        << id.getFilename()   << ", " << id.getPosition()
-        << ", " << id.getLanguage();
+    out << id.getName()       << "," << id.getType()     << ","
+        << id.getStereotype() << "," << id.getCategory() << ","
+        << id.getFilename()   << "," << id.getPosition()
+        << "," << id.getLanguage();
     return out;
 }
 

--- a/identifierName.hpp
+++ b/identifierName.hpp
@@ -135,12 +135,14 @@ public:
     identifier(const std::string& nm,
                const std::string& cat,
                const std::string& pos,
+               const std::string& st,
                const std::string& fname,
                const std::string& flang,
                const std::string& typ="") {
         name = nm;
         category = cat;
         position = pos;
+        stereotype = st;
         filename = fname;
         language = flang;
         type = typ;
@@ -149,6 +151,7 @@ public:
     std::string getName() const {return name;};
     std::string getCategory() const {return category;};
     std::string getPosition() const {return position;};
+    std::string getStereotype() const {return stereotype;};
     std::string getFilename() const {return filename;};
     std::string getLanguage() const {return language;};
     std::string getType() const {return type;};
@@ -157,6 +160,7 @@ protected:
     std::string name;        //The identifier name
     std::string category;    //Label from IDENTIFIER_TYPES
     std::string position;    //line:column
+    std::string stereotype;  //Space separated list of stereotypes
     std::string filename;    //File the identifier occurs
     std::string language;    //The programming language the name was in
     std::string type;        //Optional type for decls and functions
@@ -164,9 +168,10 @@ protected:
 
 //CSV output name, category, filename, position
 std::ostream& operator<<(std::ostream& out, const identifier& id) {
-    out << id.getName()     << ", " << id.getType()     << ", "
-        << id.getCategory() << ", " << id.getFilename() << ", "
-        << id.getPosition() << ", " << id.getLanguage();
+    out << id.getName()       << ", " << id.getType()     << ", "
+        << id.getStereotype() << ", " << id.getCategory() << ", "
+        << id.getFilename()   << ", " << id.getPosition()
+        << ", " << id.getLanguage();
     return out;
 }
 

--- a/identifierName.hpp
+++ b/identifierName.hpp
@@ -183,10 +183,10 @@ protected:
 
 //CSV output name, category, filename, position
 std::ostream& operator<<(std::ostream& out, const identifier& id) {
-    out << id.getName()       << "," << id.getType()     << ","
-        << id.getStereotype() << "," << id.getCategory() << ","
-        << id.getFilename()   << "," << id.getPosition()
-        << "," << id.getLanguage();
+    out        << id.getName()        << "," << id.getType()
+        << "," << id.getCategory()    << "," << id.getFilename()
+        << "," << id.getPosition()    << "," << id.getLanguage()
+        << "," << id.getStereotype();
     return out;
 }
 

--- a/nameCollector.cpp
+++ b/nameCollector.cpp
@@ -38,7 +38,7 @@ bool           DEBUG = false;                     // Debug flag from CLI option
 // Print out coma separated output (CSV) - no header
 // identifier, type, category, filename, position
 void printCSV(std::ostream& out, const std::vector<identifier>& identifiers) {
-    //out << "IDENTIFIER" << ", TYPE" << ", CATEGORY" << ", FILENAME" << ", POSITION" << ", LANGUAGE" << std::endl;
+    //out << "IDENTIFIER" << ", TYPE" << ", CATEGORY" << ", FILENAME" << ", POSITION" << ", LANGUAGE" << ", STEREOTYPE" << std::endl;
     for (unsigned int i = 0; i < identifiers.size(); ++i)
         out << identifiers[i] << std::endl;
 }

--- a/nameCollector.cpp
+++ b/nameCollector.cpp
@@ -48,8 +48,9 @@ void printReport(std::ostream& out, const std::vector<identifier>& identifiers) 
     out << "The following " << identifiers.size() << " user defined identifiers occur: " << std::endl;
     for (unsigned int i = 0; i<identifiers.size(); ++i) {
         out << identifiers[i].getName()
-            << " is a " << identifiers[i].getType()
-            << (identifiers[i].getType() != "" ? " " : "") << identifiers[i].getCategory()
+            << " is a " << identifiers[i].getStereotype() << (identifiers[i].getStereotype() != "" ? " " : "")
+            << identifiers[i].getType() << (identifiers[i].getType() != "" ? " " : "")
+            << identifiers[i].getCategory()
             << " in " << identifiers[i].getLanguage() << " file: " << identifiers[i].getFilename()
             << (identifiers[i].getPosition() != "" ? " at " : "") <<  identifiers[i].getPosition()
             << std::endl;

--- a/nameCollectorHandler.hpp
+++ b/nameCollectorHandler.hpp
@@ -193,7 +193,13 @@ public:
 
         else if (std::string(localname) == "type") {
             // Check if this is a type ref=prev
-            if (numAttributes >= 1 && std::string(attributes[0].value) == "prev") { } // ignore if it is
+            bool isPrevType = false;
+            for (int i = 0; i < numAttributes; ++i) {
+                if (std::string(attributes[i].localname) == "prev") {
+                    isPrevType = true;
+                }
+            }
+            if (isPrevType) { } // ignore if it is
             else {
                 typeInfo insertType;
                 // If parent tag is a decl, check if grandparent is decl_stmt.
@@ -210,7 +216,7 @@ public:
         else if (isStereotypableCategory(localname)) {
             // Check for stereotype information from stereocode
             for (int i = 0; i < numAttributes; ++i) {
-                if (std::string(attributes[i].prefix) == "st" && std::string(attributes[i].localname) == "stereotype") {
+                if (attributes[i].prefix != 0 && std::string(attributes[i].prefix) == "st" && std::string(attributes[i].localname) == "stereotype") {
                     stereotypeStack.push_back(attributes[i].value);
                     break;
                 }

--- a/nameCollectorHandler.hpp
+++ b/nameCollectorHandler.hpp
@@ -184,7 +184,7 @@ public:
         if (std::string(localname) == "name") {
             collectContent = true;
             for(int i = 0; i < numAttributes; ++i) {
-                if (attributes[i].prefix == "pos" && attributes[i].localname == "start") {
+                if (std::string(attributes[i].prefix) == "pos" && std::string(attributes[i].localname) == "start") {
                     position = attributes[i].value;
                     break;
                 }
@@ -207,12 +207,11 @@ public:
             }
         }
 
-        else if (std::string(localname) == "function" || std::string(localname) == "class") {
+        else if (isStereotypableCategory(localname)) {
             // Check for stereotype information from stereocode
             for (int i = 0; i < numAttributes; ++i) {
-                // std::cout << attributes[i].prefix << attributes[i].localname << ":" << attributes[i].value << std::endl;
-                if (attributes[i].prefix == "st" && attributes[i].localname == "stereotype") {
-                    stereotype = attributes[i].value;
+                if (std::string(attributes[i].prefix) == "st" && std::string(attributes[i].localname) == "stereotype") {
+                    stereotypeStack.push_back(attributes[i].value);
                     break;
                 }
             }
@@ -292,9 +291,14 @@ public:
                     else if (isLocal()) category = "local";
                     else if (isField()) category = "field";
                 }
+                
                 std::string type = (isTypedCategory(category) && typeStack.size() != 0 ? typeStack[typeStack.size()-1].type : "");
                 replaceSubStringInPlace(type,",","&#44;");
                 replaceSubStringInPlace(type,"\n","");
+
+                std::string stereotype = (isStereotypableCategory(category) && stereotypeStack.size() != 0 ? stereotypeStack[stereotypeStack.size() - 1] : "");
+                if (stereotypeStack.size() != 0) stereotypeStack.pop_back();
+
                 identifiers.push_back(identifier(content, category, position, stereotype, srcFileName, srcFileLanguage, type));
 
                 if (DEBUG) {  //For Debugging
@@ -456,7 +460,7 @@ private:
     bool                     collectContent;     //Flag to collect characters
     std::string              content;            //Content collected
     std::string              position;           //The position of content
-    std::string              stereotype;         //Optional stereotype info of funcs/classes
+    std::vector<std::string> stereotypeStack;    //Optional stereotype info of funcs/classes
     std::vector<std::string> elementStack;       //Stack of srcML tags
     std::string              srcFileName;        //Current source code file name (vs xml)
     std::string              srcFileLanguage;    //Current source code language


### PR DESCRIPTION
This update adds the optional collection of any stereotype information from the [stereocode](https://github.com/srcML/stereocode) tool.

Any stereotypes present within the srcML will be automatically gathered.